### PR TITLE
Add Link to Letra Github Page Inside Options Menu

### DIFF
--- a/client/src/style/options.scss
+++ b/client/src/style/options.scss
@@ -71,6 +71,6 @@
   transition: all 0.8s;
 }
 
-.contribute-link {
+.noWrap {
   white-space: nowrap;
 }

--- a/client/src/style/options.scss
+++ b/client/src/style/options.scss
@@ -71,6 +71,6 @@
   transition: all 0.8s;
 }
 
-.noWrap {
+.nowrap {
   white-space: nowrap;
 }

--- a/client/src/style/options.scss
+++ b/client/src/style/options.scss
@@ -70,3 +70,7 @@
   margin-top: $spacing-s;
   transition: all 0.8s;
 }
+
+.contribute-link {
+  white-space: nowrap;
+}

--- a/client/src/views/Options.vue
+++ b/client/src/views/Options.vue
@@ -21,6 +21,10 @@ div
         @click="save"
       ) Save
       .has-text-centered.is-text-primary.mt1.message {{ message }}
+      .has-text-centered 
+        a.contribute-link(
+          :href="contributeLink"
+        ) {{ contributeLinkText }}
 </template>
 
 <script>
@@ -50,6 +54,8 @@ export default {
     return {
       showOptions: false,
       message: '',
+      contributeLink: 'https://github.com/jayehernandez/letra-extension', 
+      contributeLinkText: 'Contribute on Github'
     };
   },
   mounted() {

--- a/client/src/views/Options.vue
+++ b/client/src/views/Options.vue
@@ -22,7 +22,7 @@ div
       ) Save
       .has-text-centered.is-text-primary.mt1.message {{ message }}
       .has-text-centered 
-        a.contribute-link(
+        a.noWrap(
           :href="contributeLink"
         ) {{ contributeLinkText }}
 </template>

--- a/client/src/views/Options.vue
+++ b/client/src/views/Options.vue
@@ -22,7 +22,7 @@ div
       ) Save
       .has-text-centered.is-text-primary.mt1.message {{ message }}
       .has-text-centered 
-        a.noWrap(
+        a.nowrap(
           :href="contributeLink"
         ) {{ contributeLinkText }}
 </template>


### PR DESCRIPTION
Here's my PR for #48. I'm going to be surprised if I got everything in one go, but figured it would be good to at least start a conversation about the changes I have so far. I'll also explain my changes below:

- I noticed for the styles there was already a fair amount of styling defined in base.scss so the only real styling I added was nowrap to prevent the text from going to the next line and I added the has-text-centered class so the link text is centered with the text inside the button.

- For the component, I just added two new properties inside of the data object as that seemed to be the place to initialize values and I thought it would be best not to hard code the link or the text inside of the template.

I also had a few general questions. Is Letra currently set up to use a linter? I noticed ESLint is part of the project, but when I do npm run lint it tells me to generate a config file. Just wanted to double check so that I can fix any linter errors if ESLint is being used. My other question was in regards to unit testing. It does not look like anything has been setup yet in that regard. Are there plans to add Jasmine or Jest in the future?

Anyway, hope you don't mind the lengthy comment! I look forward to any feedback.