### PR TITLE
Add language name on hover over flag

### DIFF
--- a/client/src/style/app.scss
+++ b/client/src/style/app.scss
@@ -3,6 +3,7 @@
 @import "base";
 @import "loading";
 @import "options";
+@import "flag";
 
 /* <---------------- DAILY WORD ----------------> */
 
@@ -76,8 +77,8 @@ h3 {
 /* <---------------- CORNER ELEMENTS ----------------> */
 .top-left {
   position: absolute;
-  top: $spacing;
-  left: $spacing;
+  cursor: default;
+  text-align: center;
 }
 
 .top-right {

--- a/client/src/style/base.scss
+++ b/client/src/style/base.scss
@@ -112,3 +112,45 @@ svg:focus {
   animation-name: fadeIn;
   animation-timing-function: ease-out;
 }
+
+@keyframes fadeInDown {
+  0% {
+    opacity: 0;
+    -webkit-transform: translateY(-5px);
+    -ms-transform: translateY(-5px);
+    transform: translateY(-5px);
+  }
+  100% {
+    opacity: 1;
+    -webkit-transform: translateY(0);
+    -ms-transform: translateY(0);
+    transform: translateY(0);
+  }
+}
+
+.fadeInDown {
+  animation-name: fadeInDown;
+  animation-timing-function: ease-out;
+  animation-fill-mode: forwards;
+}
+
+@keyframes fadeOutUp {
+  0% {
+    opacity: 1;
+    -webkit-transform: translateY(0);
+    -ms-transform: translateY(0);
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    -webkit-transform: translateY(-5px);
+    -ms-transform: translateY(-5px);
+    transform: translateY(-5px);
+  }
+}
+
+.fadeOutUp {
+  animation-name: fadeOutUp;
+  animation-timing-function: ease-out;
+  animation-fill-mode: forwards;
+}

--- a/client/src/style/flag.scss
+++ b/client/src/style/flag.scss
@@ -1,0 +1,10 @@
+.flag {
+  margin-top: $spacing;
+  margin-left: $spacing;
+  margin-right: calc(#{$spacing} + 0.2em);
+}
+
+.language-name {
+  max-width: calc(56px + 2 * #{$spacing});
+  margin: 0 auto;
+}

--- a/client/src/views/Flag.vue
+++ b/client/src/views/Flag.vue
@@ -1,6 +1,20 @@
 <template lang="pug">
-.top-left.icon.fadeIn(v-wow data-wow-duration="2s" :key="flagClass")
-  i(:class="flagClass")
+.top-left
+  .flag.fadeIn(v-wow data-wow-duration="2s" :key="flagClass")
+    i(
+      :class="flagClass"
+      @mouseover="showLanguage = true"
+      @mouseleave="showLanguage = false"
+    )
+  .language-name(
+    v-bind:class=`{
+      fadeInDown: showLanguage === true,
+      fadeOutUp: showLanguage === false,
+    }`
+    v-wow
+    data-wow-duration="0.5s"
+    v-if="showLanguage !== null"
+  ) {{ flagLanguage | titleize }}
 </template>
 
 <script>
@@ -14,6 +28,14 @@ export default {
     flagClass() {
       return `twa twa-4x ${this.dailyData.language.flag}`;
     },
+    flagLanguage() {
+      return this.dailyData.word.language;
+    },
+  },
+  data() {
+    return {
+      showLanguage: null,
+    };
   },
 };
 </script>

--- a/server/routes/letra.js
+++ b/server/routes/letra.js
@@ -46,7 +46,10 @@ router.get('/daily', async (req, res, next) => {
   const words = require(`./../data/words/${selectedLanguage}`);
 
   const language = languages[selectedLanguage];
-  const word = getRandomChoice(words);
+  const word = {
+    ...getRandomChoice(words),
+    language: selectedLanguage,
+  };
   const quote = getRandomChoice(quotes);
   const photo = await getPhoto();
 


### PR DESCRIPTION
This PR adds ability to see current language name when hovered over flag as discussed in #237 

Along with changes in Flag view on client, this also updates `/daily` route on server to send selected language in response.
(as there was no other way to get current word language on client side from old response)

Short description of changes made on client side:
- Updated styling for top-left section & added some extra styling for flag view to better accommodate language name.
- Added keyframe animation & classes for FadeInDown & FadeOutUp effect on language name.
- Updated flag view with language name & mouse events.

Screen-grab of the new effect (might be bit blurry in gif):
![hover-over-flag](https://user-images.githubusercontent.com/22729516/87848328-ce7f8980-c8fc-11ea-9fc1-94e7f4245ec7.gif)


_Suggest any changes if required._