### PR TITLE
Fix typo in Czech language

### DIFF
--- a/docs/supported_voices.md
+++ b/docs/supported_voices.md
@@ -55,7 +55,7 @@ Arabic Male
 Arabic Female  
 Armenian Male  
 Czech Female  
-Czeck Male  
+Czech Male  
 Danish Female  
 Danish Male  
 Esperanto Male  


### PR DESCRIPTION
This is a fix for the typo: "Czeck Male" to "Czech Male" in `supported_voices.md`. I am not sure if that typo was intentional, or if fixing it will break something — if that is the case, feel free to close this.

<!--Please select specific checklist(Quote/Language) according to PR and make sure to check the following boxes by putting x in the [ ] (Example: [x]). Remove the checklists that are NOT related to your PR. Thank you for your contribution-->