### PR TITLE
Fix Daily Word: H1 & H2 overlapping 

### DIFF
--- a/client/src/style/app.scss
+++ b/client/src/style/app.scss
@@ -19,7 +19,7 @@ h2 {
   text-transform: uppercase;
   letter-spacing: $spacing-xs;
   font-size: 2.5vw;
-  margin-top: -10px;
+  margin-top: 0px;
   color: $secondary-color;
 }
 


### PR DESCRIPTION
This fixes #364 .

I removed margin-top.
-10px margin was causing the overlap.

After FIX:
![Screenshot (19)](https://user-images.githubusercontent.com/43847374/94994026-9bbb6800-05b2-11eb-8c87-68b102f80fa2.png)