### PR TITLE
Added webstoreLink to the error page

### DIFF
--- a/client/src/style/base.scss
+++ b/client/src/style/base.scss
@@ -24,6 +24,7 @@ body {
 
 .is-text-primary { color: $primary-color; }
 .is-text-secondary { color: $secondary-color; }
+.is-underlined { text-decoration: underline; }
 
 .mb0 { margin-bottom: 0; }
 .mb1 { margin-bottom: $spacing-xs; }

--- a/client/src/views/ErrorPage.vue
+++ b/client/src/views/ErrorPage.vue
@@ -4,11 +4,19 @@
   .quote-container.sentence
     | An error occured.
     br
-    | Please go to the support tab of the extension if this continues!
+    | Please go to the 
+    a.is-text-primary.is-underlined(:href="webstoreLink") {{ webstoreText }}
+    |  of the extension if this continues!
 </template>
 
 <script>
 export default {
   name: 'ErrorPage',
+  data() {
+    return {
+      webstoreLink: 'https://chrome.google.com/webstore/detail/letra/cjodkkjokggcaeacdhjliobekbnnmoio',
+      webstoreText: 'support tab',
+    };
+  },
 };
 </script>

--- a/client/src/views/ErrorPage.vue
+++ b/client/src/views/ErrorPage.vue
@@ -14,7 +14,8 @@ export default {
   name: 'ErrorPage',
   data() {
     return {
-      webstoreLink: 'https://chrome.google.com/webstore/detail/letra/cjodkkjokggcaeacdhjliobekbnnmoio',
+      webstoreLink:
+        'https://chrome.google.com/webstore/detail/letra/cjodkkjokggcaeacdhjliobekbnnmoio',
       webstoreText: 'support tab',
     };
   },


### PR DESCRIPTION
This PR fixes #375 

I added the link to the support page.
It looks like this now-

![Screenshot (23)](https://user-images.githubusercontent.com/43847374/95020159-266d9700-0687-11eb-86bb-060dbb8bc0ed.png)

Should I change the text to-
1. Please go to the support section on the ChromeStore ([here](https://chrome.google.com/webstore/detail/letra/cjodkkjokggcaeacdhjliobekbnnmoio)) if this continues!

It gives clear context on what to do next.

Or should I leave the text as it was and create a support tab button instead?
like this one-

![Screenshot (25)](https://user-images.githubusercontent.com/43847374/95020830-24a5d280-068b-11eb-9f1f-6dcf027e45a3.png)

> Learnt some PUG while solving a BUG.