### PR TITLE
add unit test for Time view

### DIFF
--- a/client/test/src/views/Time.test.js
+++ b/client/test/src/views/Time.test.js
@@ -1,0 +1,30 @@
+import { shallowMount } from '@vue/test-utils';
+import { jest } from '@jest/globals';
+import Time from '../../../src/views/Time';
+
+describe('Time', () => {
+  let wrapper;
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    wrapper = shallowMount(Time);
+  });
+
+  it('is a Vue instance', () => {
+    expect(wrapper.vm).toBeTruthy();
+  });
+
+  it('renders date component', () => {
+    expect(wrapper.find('.date').exists()).toBeTruthy();
+  });
+
+  it('renders time component', () => {
+    expect(wrapper.find('.time').exists()).toBeTruthy();
+  });
+
+  test('should call getNow()', () => {
+    jest.advanceTimersByTime(1000);
+    expect(setInterval).toHaveBeenCalledTimes(1);
+    expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+  });
+});


### PR DESCRIPTION
**Added a unit test for Time view** related to issue #124 

Test cases (very basic):
- if `Time` renders all the necessary component
- if `Time` calls `getNow()` which then calls `setInterval()`

Will need to: 
- test if the `.date` and `.time` elements in `Time` view renders actual dates and time ( I was having trouble with this) 

However, coverage for Time is currently 100%. 

<img width="1437" alt="Screen Shot 2020-10-10 at 3 17 37 PM" src="https://user-images.githubusercontent.com/46255649/95663285-036e3780-0b0c-11eb-83f0-7100d3dadda3.png">
