### PR TITLE
Added contribution info log

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -48,6 +48,12 @@ Vue.directive('click-outside', {
   },
 });
 
+// A log to be viewed in dev tools with contribution info
+console.log(
+  "%c Welcome to dev tools on Letra! If you'd like to learn more about this repo please visit: https://github.com/jayehernandez/letra-extension ✨",
+  'background: #1e264e; color: #d9c278',
+);
+
 (() =>
   new Vue({
     el: '#app',


### PR DESCRIPTION
This adds a log message to the dev tools of a browser with contribution information.

Here's what it looks like in Chrome dev tools:

<img width="917" alt="Screenshot 2020-10-12 at 1 43 13 PM" src="https://user-images.githubusercontent.com/11731837/95721933-e9aa2d00-0c90-11eb-8ce3-3985475c6f95.png">
