### PR TITLE
Improved test for Time view (100%)

### DIFF
--- a/client/src/views/Time.vue
+++ b/client/src/views/Time.vue
@@ -19,24 +19,27 @@ export default {
   methods: {
     getNow() {
       setInterval(() => {
-        const today = new Date();
-
-        // Calculate time in 12-hour format
-        const time = today.toLocaleTimeString([], {
-          hour: '2-digit',
-          minute: '2-digit',
-        });
-        this.computedTime = time;
-
-        // Compute date according to the current locale
-        today.toLocaleString('default', { month: 'long' });
-        const date = today.toLocaleDateString([], {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        });
-        this.computedDate = date;
+        this.getDateTime();
       }, 1000);
+    },
+    getDateTime() {
+      const today = new Date();
+
+      // Calculate time in 12-hour format
+      const time = today.toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      this.computedTime = time;
+
+      // Compute date according to the current locale
+      today.toLocaleString('default', { month: 'long' });
+      const date = today.toLocaleDateString([], {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+      this.computedDate = date;
     },
   },
 };

--- a/client/test/src/views/Time.test.js
+++ b/client/test/src/views/Time.test.js
@@ -22,9 +22,28 @@ describe('Time', () => {
     expect(wrapper.find('.time').exists()).toBeTruthy();
   });
 
-  test('should call getNow()', () => {
+  it('should call getNow()', () => {
     jest.advanceTimersByTime(1000);
     expect(setInterval).toHaveBeenCalledTimes(1);
     expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+  });
+
+  it('should render date and time correctly', () => {
+    const today = new Date();
+
+    expect(wrapper.find('.time').text()).toBe(
+      today.toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+    );
+
+    expect(wrapper.find('.date').text()).toBe(
+      today.toLocaleDateString([], {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      }),
+    );
   });
 });


### PR DESCRIPTION
**Improved unit test for Time view** related to issue #124 and PR #428 


**Changes**: 
- I extracted date and time outside of `setInterval()` by declaring a method `getDateTime()` so that `getNow()` would call `setInterval()` which calls `getDateTime()`. 
- Added 2 tests to check if date and time are rendered correctly and they did. 
- Coverage remains 100% for lines, functions, branches, and statements. 

<img width="1439" alt="Screen Shot 2020-10-12 at 2 32 41 PM" src="https://user-images.githubusercontent.com/46255649/95779291-cb93fb00-0c97-11eb-884a-e3a76f990240.png">
