### PR TITLE
Fix spaces in Pug templates

### DIFF
--- a/client/src/views/Credit.vue
+++ b/client/src/views/Credit.vue
@@ -1,11 +1,11 @@
 <template lang="pug">
 .bottom-left
-  | Photo by
-  a(:href="photoLink")  {{ photographerData.name }}
-  |  on
-  a(href="https://unsplash.com/?utm_source=letra&utm_medium=referral")  Unsplash
-  |  | Text to Speech provided by
-  a(href="https://responsivevoice.org/")  responsivevoice.org
+  | Photo by#{' '}
+  a(:href="photoLink") {{ photographerData.name }}
+  |  on#{' '}
+  a(href="https://unsplash.com/?utm_source=letra&utm_medium=referral") Unsplash
+  |  | Text to Speech provided by#{' '}
+  a(href="https://responsivevoice.org/") responsivevoice.org
 </template>
 
 <script>

--- a/client/src/views/ErrorPage.vue
+++ b/client/src/views/ErrorPage.vue
@@ -4,7 +4,7 @@
   .quote-container.sentence
     | An error occurred.
     br
-    | Please go to the 
+    | Please go to the#{' '}
     a.is-text-primary.is-underlined(:href="webstoreLink") {{ webstoreText }}
     |  of the extension if this continues!
 </template>


### PR DESCRIPTION
`ErrorPage.vue`: Replaced the trailing space with [string interpolation](https://pugjs.org/language/interpolation.html). Now the code doesn't look as nice, but I'd argue that having trailing whitespace in code files is worse. They are hard to notice, and some devs (like me, hi!) even have an option in their code editor to trim trailing whitespace when saving a file. (In VS Code, it's the "Editor: Trim Auto Whitespace" setting.) This can lead to confusing behavior ("Why is there an extra space? Oh, it's from that trailing space which I didn't notice") and bugs ("Where did the space go?! Oh, it was removed automatically by my code editor").

An alternative would be to output a string containing a space (see ["Buffered code" on Pug docs](https://pugjs.org/language/code.html#buffered-code)), but I don't think this is any clearer:

```pug
.bottom-left
  | Photo by
  = ' '
  a(:href="photoLink") {{ photographerData.name }}
  // ...
```

`Credit.vue`: Moved leading spaces from link texts to the previous non-link text. This is a minor detail and not visible normally, but if you focus on one of the links using the <kbd>Tab</kbd> key, you can see that the focus outline is off (zoomed-in screenshot):

![zoomed-in screenshot of a link with focus outline](https://user-images.githubusercontent.com/2226144/97782239-17e8a180-1b99-11eb-9550-564138878038.png)