### PR TITLE
Fix time and date tests in `Time.test.js`

### DIFF
--- a/client/src/views/Time.vue
+++ b/client/src/views/Time.vue
@@ -33,7 +33,6 @@ export default {
       this.computedTime = time;
 
       // Compute date according to the current locale
-      today.toLocaleString('default', { month: 'long' });
       const date = today.toLocaleDateString([], {
         year: 'numeric',
         month: 'long',

--- a/client/test/src/views/Time.test.js
+++ b/client/test/src/views/Time.test.js
@@ -3,11 +3,30 @@ import { jest } from '@jest/globals';
 import Time from '../../../src/views/Time';
 
 describe('Time', () => {
+  let dateSpy;
   let wrapper;
 
   beforeAll(() => {
     jest.useFakeTimers();
+
+    const mockDate = new Date('2020-03-10, 1:23:45 PM');
+    const mockDate2 = new Date(mockDate.getTime());
+
+    // Make `new Date()` return this specific date
+    dateSpy = jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+    // Force `en-US` as the locale since the default value can be different on
+    // different developers' machines
+    mockDate.toLocaleTimeString = (locales, options) =>
+      mockDate2.toLocaleTimeString('en-US', options);
+    mockDate.toLocaleDateString = (locales, options) =>
+      mockDate2.toLocaleDateString('en-US', options);
+
     wrapper = shallowMount(Time);
+  });
+
+  afterAll(() => {
+    dateSpy.mockRestore();
   });
 
   it('is a Vue instance', () => {
@@ -29,21 +48,7 @@ describe('Time', () => {
   });
 
   it('should render date and time correctly', () => {
-    const today = new Date();
-
-    expect(wrapper.find('.time').text()).toBe(
-      today.toLocaleTimeString([], {
-        hour: '2-digit',
-        minute: '2-digit',
-      }),
-    );
-
-    expect(wrapper.find('.date').text()).toBe(
-      today.toLocaleDateString([], {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      }),
-    );
+    expect(wrapper.find('.time').text()).toBe('01:23 PM');
+    expect(wrapper.find('.date').text()).toBe('March 10, 2020');
   });
 });


### PR DESCRIPTION
I noticed that the current test "should render date and time correctly" is not actually testing that the date and time are formatted correctly. It's just testing that the input and output are the same because the expected values in `Time.test.js` are specified the same way as in `Time.vue`:

```js
/* Time.vue */

// Calculate time in 12-hour format
const time = today.toLocaleTimeString([], {
  hour: '2-digit',
  minute: '2-digit',
});
this.computedTime = time;

// Compute date according to the current locale
const date = today.toLocaleDateString([], {
  year: 'numeric',
  month: 'long',
  day: 'numeric',
});
this.computedDate = date;
```

```js
/* Time.test.js */

expect(wrapper.find('.time').text()).toBe(
  today.toLocaleTimeString([], {
    hour: '2-digit',
    minute: '2-digit',
  }),
);

expect(wrapper.find('.date').text()).toBe(
  today.toLocaleDateString([], {
    year: 'numeric',
    month: 'long',
    day: 'numeric',
  }),
);
```

So the tests are basically like this:

```js
expect(
  today.toLocaleTimeString([], {
    hour: '2-digit',
    minute: '2-digit',
  })
).toBe(
  today.toLocaleTimeString([], {
    hour: '2-digit',
    minute: '2-digit',
  })
);

// + date test
```

Or basically like `expect(foo()).toBe(foo())`.

Testing that the input is the same as the output doesn't give any confidence/certainty that the values are formatted correctly.

Plus what if `today.toLocaleTimeString(/* ... */)` returned `undefined` for some reason? Then the test would be basically this:

```js
expect(undefined).toBe(undefined);
```

That's not quite what we want to test, right? 🙂

In this PR I'm explicitly defining that the expected values are `'01:23 PM'` and `'March 10, 2020'`. This way the tests will actually fail if the time and date are not correctly formatted.

***

I also removed an unnecessary line from `Time.vue`.