### PR TITLE
Add missing test to `Credit.test.js`

### DIFF
--- a/client/test/src/views/Credit.test.js
+++ b/client/test/src/views/Credit.test.js
@@ -1,21 +1,20 @@
 import { mount } from '@vue/test-utils';
 import Credit from '../../../src/views/Credit';
 
+const photographerData = {
+  name: 'test user',
+  username: 'testuser',
+}
+const dailyData = {
+  photo: {
+    user: photographerData,
+  },
+};
+
 const options = {
   computed: {
-    dailyData() {
-      return {
-        photo: {
-          user: 'test user',
-        },
-      };
-    },
-    photographerData() {
-      return {
-        name: 'test user',
-        username: 'testuser',
-      };
-    },
+    dailyData: () => dailyData,
+    photographerData: () => photographerData,
   },
 };
 
@@ -24,9 +23,16 @@ describe('Credit', () => {
     const wrapper = mount(Credit, options);
     expect(wrapper.vm).toBeTruthy();
   });
+  it ('returns data from `dailyData` when calling `photographerData()`', () => {
+    const wrapper = mount(Credit, options);
+    const data = Credit.computed.photographerData.call({ dailyData });
+    expect(data).toBe(wrapper.vm.dailyData.photo.user);
+    expect(data).toMatchObject({ name: 'test user', username: 'testuser' });
+  });
+
   it('displays photographer name', () => {
     const wrapper = mount(Credit, options);
-    const name = options.computed.dailyData().photo.user;
+    const { name } = options.computed.dailyData().photo.user;
 
     expect(wrapper.text()).toContain(`Photo by ${name}`);
   });


### PR DESCRIPTION
This bumps the coverage of `Credit.vue` to 100%. I consulted this guide for using `.call()` to test computed data: https://lmiller1990.github.io/vue-testing-handbook/computed-properties.html#testing-with-call