### PR TITLE
ported to firefox tested with firefox extension compatibility test

### DIFF
--- a/client/src/manifest.json
+++ b/client/src/manifest.json
@@ -19,5 +19,10 @@
       "background.js"
     ]
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "letra@letra.com"
+    }
+  },
   "content_security_policy": "script-src 'self' https://www.google-analytics.com https://code.responsivevoice.org/responsivevoice.js 'unsafe-eval'; object-src 'self'"
 }


### PR DESCRIPTION
Below is the step-by-step that i've done to figure out how port letra to firefox. It turns out that we only need to add something on manifest.json.
	
1. setup the server with necessary environment variables (eg: unsplash access key) and run it in the background and leave him alone 😁 hehe
	
2. built the application first $ npm run build
	
3. go to chrome://extensions/ with dev mode on
	
4. in order to test the compatibility to firefox, we need the extension's .crx file. To do this, we will pack extension using chrome, choose client/dist folder and it will output a .crx file

5. went to https://www.extensiontest.com/ to test firefox compatibility
	
	OUTPUT:
	- extension is compatible but with errors mostly with manifest.json file
		 

6. temporarily installed the extension on firefox (latest version 83.0) by following this instructions: 
(i selected the manifest.json inside the dist folder) 
https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox/
	
	OUTPUT:
	- throws an error about the manifest file
	- tried to reload the tab, manifest.json error goes away, loading svg is showing and doesnt proceed
	- sometimes goes through the loader, however list of languages is empty which suppose to be provided by the server
		 
	

7. changed the manifest.json and built the application again $ npm run build
	
8. did the same thing on steps 5/6 and its now working on firefox
	
	OUTPUT:
	- no errors on https://www.extensiontest.com/ but with some warnings about security
	- its working on firefox when installed temporarily the same way it works on chrome
		
		
			
**NOTE: 
         - the browser specific setting added on manifest.json is  used to distinguish this add-on from any other Firefox add-on.
          https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/
         - The last step would be publishing letra on addons.mozilla.org (AMO)**