### PR TITLE
[#545] Toggle button to hide/show romanization added

### DIFF
--- a/client/src/style/app.scss
+++ b/client/src/style/app.scss
@@ -33,6 +33,14 @@ h3 {
 .romanization-button {
   color: $secondary-color;
   text-transform: uppercase;
+  transition: all 0.8s;
+  opacity: 0.8;
+}
+
+.romanization-button:hover {
+  color: $primary-color;
+  transition: all 0.8s;
+  cursor: pointer;
 }
 
 .center-container {

--- a/client/src/style/app.scss
+++ b/client/src/style/app.scss
@@ -30,6 +30,11 @@ h3 {
   color: $primary-color;
 }
 
+.romanization-button {
+  color: $secondary-color;
+  text-transform: uppercase;
+}
+
 .center-container {
   display: flex;
   flex-direction: column;

--- a/client/src/views/Word.vue
+++ b/client/src/views/Word.vue
@@ -5,8 +5,15 @@
     :key="dailyData.word.word"
     v-if="!loading"
   )
+
     .daily-word-container
-      h3.mb0 {{ dailyData.word.romanization || '' }}
+      span(
+        v-show='isButtonVisible(dailyData.word.romanization)'
+        class="romanization-button" 
+        type="button" value="pinyin"
+        @click="togglePinyin"
+      ) {{ this.pinyinVal }} 
+      h3(class='mb0' v-show='isVRomanizationVisible()') {{ dailyData.word.romanization || '' }}
       .is-flex.is-justify-centered
         h1(
           v-bind:style="{ 'font-size': calculateFontSizeForDailyWord }"
@@ -51,6 +58,9 @@ export default {
       return '10vw';
     },
   },
+  data: function () {
+    return {isRomanizationVisible:true, romanizationVal:"Hide Romanization"}
+  },
   methods: {
     speak() {
       // eslint-disable-next-line
@@ -59,6 +69,24 @@ export default {
         this.dailyData.language.voice,
       );
     },
+    isVRomanizationVisible(){
+      return this.$data.isRomanizationVisible;
+    },
+    togglePinyin(){
+      this.$data.isRomanizationVisible = !this.$data.isRomanizationVisible;
+      if (this.$data.romanizationnVal == "Hide Romanization") {
+        this.$data.romanizationVal = "Show Romanization"
+      } else {
+        this.$data.romanizationVal = "Hide Romanization"
+      }
+    },
+    isButtonVisible(val) {
+      if (val) {
+        return true;
+      } else {
+        return false;
+      }
+    }
   },
 };
 </script>

--- a/client/src/views/Word.vue
+++ b/client/src/views/Word.vue
@@ -10,9 +10,9 @@
       span(
         v-show='isButtonVisible(dailyData.word.romanization)'
         class="romanization-button" 
-        type="button" value="pinyin"
-        @click="togglePinyin"
-      ) {{ this.pinyinVal }} 
+        type="button" value="romanization"
+        @click="toggleRomanization"
+      ) {{ this.romanizationVal }} 
       h3(class='mb0' v-show='isVRomanizationVisible()') {{ dailyData.word.romanization || '' }}
       .is-flex.is-justify-centered
         h1(
@@ -72,9 +72,9 @@ export default {
     isVRomanizationVisible(){
       return this.$data.isRomanizationVisible;
     },
-    togglePinyin(){
+    toggleRomanization(){
       this.$data.isRomanizationVisible = !this.$data.isRomanizationVisible;
-      if (this.$data.romanizationnVal == "Hide Romanization") {
+      if (this.$data.romanizationVal == "Hide Romanization") {
         this.$data.romanizationVal = "Show Romanization"
       } else {
         this.$data.romanizationVal = "Hide Romanization"

--- a/client/test/src/views/Word.test.js
+++ b/client/test/src/views/Word.test.js
@@ -39,18 +39,61 @@ describe('Word', () => {
       expect(wordWrapper.exists()).toBeTruthy();
     });
 
-    it('displays romanization correctly', () => {
-      const romanizationSelector = '.daily-word-container h3';
+    describe('when romanization value exists', () => {
+      it('displays romanization correctly', () => {
+        const romanizationSelector = '.daily-word-container h3';
+  
+        expect(wrapper.find(romanizationSelector).exists()).toBeTruthy();
+        expect(wrapper.find(romanizationSelector).text()).toBe('');
+  
+        store.state.dailyData.word.romanization = 'romanization';
+        wrapper = shallowMount(Word, { store, localVue });
+  
+        expect(wrapper.find(romanizationSelector).text()).toBe(
+          wrapper.vm.dailyData.word.romanization,
+        );
+  
+        expect(wrapper.find(romanizationSelector).element.style.display).not.toBe(
+          'none'
+        );
+      });
+  
+      it('displays the romanization button correctly', () => {
+        const romanizationButtonSelector = '.romanization-button';
+  
+        expect(wrapper.find(romanizationButtonSelector).exists()).toBeTruthy();
+  
+        expect(wrapper.find(romanizationButtonSelector).element.style.display).not.toBe(
+          'none'
+        );
 
-      expect(wrapper.find(romanizationSelector).exists()).toBeTruthy();
-      expect(wrapper.find(romanizationSelector).text()).toBe('');
+        expect(wrapper.find(romanizationButtonSelector).text()).toBe('Hide Romanization');
+      });
 
-      store.state.dailyData.word.romanization = 'romanization';
-      wrapper = shallowMount(Word, { store, localVue });
+      it('triggers the romanization button correctly', async () => {
+        const romanizationButton = wrapper.find('.romanization-button');
+        
+        await romanizationButton.trigger('click');
+  
+        expect(wrapper.find('.romanization-button').text()).toBe('Show Romanization');
+      });
 
-      expect(wrapper.find(romanizationSelector).text()).toBe(
-        wrapper.vm.dailyData.word.romanization,
-      );
+    });
+
+    describe('when romanization value does not exist', () => {  
+      it('does not display the romanization button', () => {
+        store.state.dailyData.word.romanization = null;
+        wrapper = shallowMount(Word, { store, localVue });
+
+        const romanizationButtonSelector = '.romanization-button';
+  
+        expect(wrapper.find(romanizationButtonSelector).exists()).toBeTruthy();
+  
+        expect(wrapper.find(romanizationButtonSelector).element.style.display).toBe(
+          'none'
+        );
+      });
+
     });
 
     it('displays daily word correctly', () => {

--- a/client/test/src/views/Word.test.js
+++ b/client/test/src/views/Word.test.js
@@ -71,11 +71,32 @@ describe('Word', () => {
       });
 
       it('triggers the romanization button correctly', async () => {
+        const romanizationSelector = '.daily-word-container h3';
+        const romanizationButtonSelector = '.romanization-button';
         const romanizationButton = wrapper.find('.romanization-button');
         
+        // Click to hide romanization
         await romanizationButton.trigger('click');
   
-        expect(wrapper.find('.romanization-button').text()).toBe('Show Romanization');
+        expect(wrapper.find(romanizationButtonSelector).text()).toBe('Show Romanization');
+
+        expect(wrapper.find(romanizationSelector).element.style.display).toBe(
+          'none'
+        );
+        
+        // Click to show romanization again
+        await romanizationButton.trigger('click');
+
+        expect(wrapper.find(romanizationButtonSelector).text()).toBe('Hide Romanization');
+
+        expect(wrapper.find(romanizationSelector).element.style.display).not.toBe(
+          'none'
+        );
+
+        expect(wrapper.find(romanizationSelector).text()).toBe(
+          wrapper.vm.dailyData.word.romanization,
+        );
+
       });
 
     });


### PR DESCRIPTION
@bhavinip and I added a button to show/hide romanization as suggested in #545! 

We extended it beyond Chinese and made it so that the button shows up in all languages that have romanization information available. We also made it so that it does not show up in languages that do not have the information available. In the default state the romanization is displayed and the button (positioned above it) says 'Hide romanization.' When the button is pressed it hides the romanization and then says 'Show romanization.' This part was implemented in Word.vue.

We also wanted to keep the button consistent with letra's existing aesthetic so when you hover over it, it turns yellow like the other buttons and the cursor also changes to a pointer! (made changes in app.scss for this). 

Finally, we also added some tests in the file Word.test.js that check to make sure that:
1. The romanization text is visible when the information is available.
2. The romanization button is visible when the information is available and says 'Hide romanization' in the default state.
3. The romanization button says 'Show romanization' after being clicked and hides the romanization. When it is clicked again it says 'Hide romanization' and displays the romanization.
4. The romanization button is not visible when the romanization information is not available.