### PR TITLE
Adjust flag list layout to prevent content overflow

### DIFF
--- a/client/src/style/app.scss
+++ b/client/src/style/app.scss
@@ -5,6 +5,36 @@
 @import "options";
 @import "flag";
 
+// Custom Scrollbar
+
+::-webkit-scrollbar {
+  width: 18px;
+}
+
+::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: #d6dee1;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: #d6dee1;
+  border-radius: 20px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: #d6dee1;
+  border-radius: 20px;
+  border: 6px solid transparent;
+  background-clip: content-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: #a8bbbf;
+}
+
 /* <---------------- DAILY WORD ----------------> */
 
 h1 {

--- a/client/src/style/flag.scss
+++ b/client/src/style/flag.scss
@@ -18,3 +18,8 @@
   margin-bottom: 10px;
   color: $primary-color;
 }
+
+.flag-list-container {
+  max-height: calc(100vh - 220px);
+  overflow-y: auto;
+}

--- a/client/src/style/options.scss
+++ b/client/src/style/options.scss
@@ -2,7 +2,7 @@
   position: absolute;
   top: 70px;
   right: 20px;
-  width: 15%;
+  width: 20%;
   background: rgba(0, 0, 0, 0.4);
   border-radius: 10px;
   padding: $spacing-s;
@@ -31,6 +31,8 @@
   background: black;
   padding: 8px 25px 0px 8px;
   border: 1px solid $third-color;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .multiselect__content-wrapper {

--- a/client/src/views/Flag.vue
+++ b/client/src/views/Flag.vue
@@ -1,37 +1,39 @@
 <template lang="pug">
 .top-left
-  .flag.fadeIn(v-wow data-wow-duration="2s" :key="flagClass")
-    i(
-      :class="flagClass"
-      @mouseover="showLanguage = true"
-      @mouseleave="showLanguage = false"
-      @click="toggleFlagDropdown"
-    )
-  .language-name(
-    v-bind:class=`{
-      fadeInDown: showLanguage === true,
-      fadeOutUp: showLanguage === false,
-    }`
-    v-wow
-    data-wow-duration="0.5s"
-    v-if="showLanguage !== null"
-  ) {{ flagLanguage | titleize }}
+  div(style={width:'fit-content'})
+    .flag.fadeIn(v-wow data-wow-duration="2s" :key="flagClass")
+      i(
+        :class="flagClass"
+        @mouseover="showLanguage = true"
+        @mouseleave="showLanguage = false"
+        @click="toggleFlagDropdown"
+      )
+    .language-name(
+      v-bind:class=`{
+        fadeInDown: showLanguage === true,
+        fadeOutUp: showLanguage === false,
+      }`
+      v-wow
+      data-wow-duration="0.5s"
+      v-if="showLanguage !== null"
+    ) {{ flagLanguage | titleize }}
   transition(name="fade")
     div(v-if="showLanguageDropdown")
       .flag-options Show in:
-      .flag-list(v-for="(language, index) in otherLanguages")
-        .flag.fadeIn(
-          v-wow
-          data-wow-duration="2s"
-          :key="dailyData.translations[language].flag"
-          v-bind:class=`{ mt0: index === 0 }`
-        )
-          i(
-            :class="dailyData.translations[language].flag"
-            class="twa twa-4x"
-            @click="toggleActiveLanguage(language); showLanguageDropdown = false;"
+      .flag-list-container
+        .flag-list(v-for="(language, index) in otherLanguages")
+          .flag.fadeIn(
+            v-wow
+            data-wow-duration="2s"
+            :key="dailyData.translations[language].flag"
+            v-bind:class=`{ mt0: index === 0 }`
           )
-        .language-name {{ language | titleize }}
+            i(
+              :class="dailyData.translations[language].flag"
+              class="twa twa-4x"
+              @click="toggleActiveLanguage(language); showLanguageDropdown = false;"
+            )
+          .language-name {{ language | titleize }}
 </template>
 
 <script>


### PR DESCRIPTION
**Problem:**

When selecting numerous flags, the content in both the left-hand flags container and the right-hand flags selection dropdown overflows beyond the viewport, exceeding `100vh` and `100vw` respectively. This creates a cluttered and visually disruptive user experience.

**Solution:**

This pull request implements a fix for the content overflow issue by applying `max-height` and `overflow` properties to both left-hand, right-hand sections. This effectively prevents content from spilling outside the designated areas, ensuring a clean and functional interface regardless of the number of selected flags.

**Visual Improvements:**

Before and after screenshots are provided for clear comparison:

* **Before:** (Attached screenshot showcasing the overflow issue)

![letra-overflow-issue-highlight-count](https://github.com/jayehernandez/letra-extension/assets/54032677/22c6eb2f-bd1b-410d-adb1-5ce2d276740c)

* **After:** (Attached screenshot showcasing the resolved overflow)

![Screenshot from 2023-12-15 21-58-02](https://github.com/jayehernandez/letra-extension/assets/54032677/d333285b-ebb0-4bb1-b042-92677a490351)


These changes improve the user experience by preventing content overflow and maintaining a consistent layout, even when numerous flags are selected.

**Technical Details:**

* The fix is implemented using CSS and doesn't affect the existing functionality of the flag selection process.
* Thorough testing on various screen sizes and browsers ensures consistent behavior across platforms.

**Call to Action:**

Your feedback on this pull request is valuable. I'm open to suggestions for further improvements and optimization.